### PR TITLE
ndnop-process-requests: add support to publish certificate to NDNS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Alexander Afanasyev  http://lasr.cs.ucla.edu/afanasyev/index.html
 Alex Horn            http://remap.ucla.edu/home/team/691-alexander-horn
 Xingyu Ma            https://www.linkedin.com/pub/xingyu-ma/1a/384/5a8
+Xiaoke Jiang         http://netarchlab.tsinghua.edu.cn/~shock/

--- a/ndnop-process-requests
+++ b/ndnop-process-requests
@@ -39,8 +39,6 @@ import socket
 ################################################################################
 
 URL = "http://ndncert.named-data.net"
-REPO_HOST = "localhost"
-REPO_PORT = 7376
 
 ################################################################################
 ################################################################################
@@ -179,14 +177,44 @@ class Signer(object):
         return cert.rstrip()
 
     def publishCertificate(self, certificate):
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect((REPO_HOST, int(REPO_PORT)))
+        # block = ndn.Block(base64.b64decode(certificate))
+        data = ndn.Data()
+        data.wireDecode(ndn.Blob(buffer(base64.b64decode(certificate))))
 
-            sock.send(base64.b64decode(certificate))
-        except Exception,e:
-            print e
-            print "ERROR: an error occurred while publishing certificate"
+        updateName = ndn.Name(self.site_prefix) \
+            .append("NDNS") \
+            .append(data.wireEncode()) \
+            .append("UPDATE")
+
+        self.face = ndn.Face()
+        
+        self.waiting = True
+        self.sendUpdate(updateName)
+                
+        while self.waiting:
+            self.face.processEvents()
+            time.sleep(0.01)
+            
+        self.face.shutdown()
+       
+    def sendUpdate(self, interestOrName):
+        self.face.expressInterest(interestOrName, self.onData, self.onTimeout)
+        
+    def onData(self, interest, data):
+        # TODO: check the result of response
+        print "Publishing succeeds: get response from NDNS name server"
+        self.waiting = False
+
+
+    def onTimeout(self, interest):
+        print "ERROR: error to publish certificate to NDNS. Update message timeout"
+        try:
+            if confirm("try to publish certificate again?", resp=False):
+                self.sendUpdate(interest)
+            else:
+                self.waiting = False
+        except RequestSkipped:
+            pass
 
 def confirm(prompt, resp):
     if resp:


### PR DESCRIPTION
This commit enable publishing certificate to NDNS as an optional (and default) choice when creating a new certificate. 
Since the testing need to configure a relative complex scenario (also, I have trouble when install Flask due to version and import problem), I just created a very simple test case in tests/
